### PR TITLE
License Encryption and Hiive API

### DIFF
--- a/includes/RestApi/Controllers/PLSController.php
+++ b/includes/RestApi/Controllers/PLSController.php
@@ -74,7 +74,7 @@ class PLSController extends \WP_REST_Controller {
 	 */
 	public function get_args() {
 		return array(
-			'plugin_slug' => array(
+			'pluginSlug' => array(
 				'required'          => true,
 				'validate_callback' => function ( $param ) {
 					return is_string( $param ) && ! empty( $param );
@@ -91,7 +91,7 @@ class PLSController extends \WP_REST_Controller {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function create_license( $request ) {
-		$plugin_slug = sanitize_text_field( $request->get_param( 'plugin_slug' ) );
+		$plugin_slug = sanitize_text_field( $request->get_param( 'pluginSlug' ) );
 
 		$response = PLSUtility::provision_license( $plugin_slug );
 

--- a/includes/Utilities/HiiveUtility.php
+++ b/includes/Utilities/HiiveUtility.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace NewfoldLabs\WP\Module\PLS\Utilities;
+
 use NewfoldLabs\WP\Module\Data\HiiveConnection;
 
 /**

--- a/includes/Utilities/PLSUtility.php
+++ b/includes/Utilities/PLSUtility.php
@@ -2,6 +2,8 @@
 
 namespace NewfoldLabs\WP\Module\PLS\Utilities;
 
+use NewfoldLabs\WP\Module\Data\Helpers\Encryption;
+
 /**
  * Class PLSUtility
  *
@@ -11,16 +13,64 @@ class PLSUtility {
 
 	/**
 	 * Provisions a new license via the Hiive PLS API using the plugin slug.
+	 * If the license is already stored (encrypted) in WordPress options, it returns the stored license.
 	 *
 	 * @param string $plugin_slug The plugin slug.
 	 *
-	 * @return array|WP_Error License status or WP_Error on failure.
+	 * @return array|WP_Error License data or WP_Error on failure.
 	 */
 	public static function provision_license( $plugin_slug ) {
-		// TODO: Replace this dummy with an actual API call to Hiive for provisioning a new license.
-		return array(
-			'status'      => 'new',
-			'downloadUrl' => 'https://hiive.cloud/workers/plugin-downloads/yith-paypal-payments-for-woocommerce',
+		$encryption = new Encryption();
+
+		$option_name       = 'nfd_module_pls_license_data_' . $plugin_slug;
+		$encrypted_license = get_option( $option_name );
+		// Check if the license already exists in WordPress options
+		if ( $encrypted_license ) {
+			$decrypted_license = $encryption->decrypt( $encrypted_license );
+			if ( $decrypted_license ) {
+				// TODO: Validate the license's validity (if necessary) once the Hiive API is ready.
+				return json_decode( $decrypted_license, true );
+			}
+
+			delete_option( $option_name );
+			return new \WP_Error(
+				'nfd_pls_error',
+				__( 'Failed to decrypt the stored license.', 'wp-module-pls' )
+			);
+		}
+
+		// License doesn't exist, so proceed with the API call to provision a new one
+		$endpoint      = '/sites/v2/pls';
+		$body          = array(
+			'pluginSlug' => $plugin_slug,
+		);
+		$hiive_request = new HiiveUtility( $endpoint, $body, 'POST' );
+
+		$response = $hiive_request->send_request();
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_body = json_decode( $response, true );
+		if ( isset( $response_body['license_id'], $response_body['download_url'] ) ) {
+			$license_data   = array(
+				'licenseId'     => $response_body['license_id'],
+				'downloadUrl'   => $response_body['download_url'],
+				'storageMethod' => 'wp_options',
+				'storageKey'    => $option_name,
+			);
+			$encrypted_data = $encryption->encrypt( wp_json_encode( $license_data ) );
+			if ( $encrypted_data ) {
+				update_option( $option_name, $encrypted_data );
+			}
+
+			return $license_data;
+		}
+
+		// If the response format is unexpected, return an error
+		return new WP_Error(
+			'nfd_pls_error',
+			__( 'Unexpected response format from the API.', 'wp-module-pls' )
 		);
 	}
 
@@ -29,10 +79,10 @@ class PLSUtility {
 	 *
 	 * @param string $plugin_slug The plugin slug.
 	 *
-	 * @return string|WP_Error License status or WP_Error on failure.
+	 * @return string|WP_Error The license status or WP_Error on failure.
 	 */
 	public static function retrieve_license_status( $plugin_slug ) {
-		// TODO: Replace this dummy with an actual API call to Hiive to retrieve the license status.
+		// TODO: Replace this dummy method with an actual API call to Hiive to retrieve the license status.
 		$statuses      = array( 'active', 'new', 'expired', 'not_generated' );
 		$random_status = $statuses[ array_rand( $statuses ) ];
 
@@ -47,7 +97,7 @@ class PLSUtility {
 	 * @return array|WP_Error License status or WP_Error on failure.
 	 */
 	public static function activate_license( $plugin_slug ) {
-		// TODO: Replace this dummy with an actual API call to Hiive to activate the license.
+		// TODO: Replace this dummy method with an actual API call to Hiive to activate the license.
 		return array(
 			'status' => 'active',
 		);


### PR DESCRIPTION
## Proposed changes

1. Calls `/sites/v2/pls` API to provision a new license if not already stored.
2. Added encryption of license data before storing in WordPress options using the `Encryption` class.
3. Decrypts and returns stored license if it exists, without calling the API.
4. License data now includes `licenseId`, `downloadUrl`, `storageMethod` (`wp_options`), and `storageKey`.

Hiive PR referenced: https://github.com/newfold-labs/laravel-hiive/pull/455

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
