### PR TITLE
Customize plugin package download url to inject license and activation key

### DIFF
--- a/includes/PLS.php
+++ b/includes/PLS.php
@@ -68,7 +68,7 @@ class PLS {
 		}
 
 		// Get the plugin slug.
-		$data = get_file_data(  WP_PLUGIN_DIR . '/' . $plugin_path, ['slug' => 'BH Slug'] );
+		$data = get_file_data( WP_PLUGIN_DIR . '/' . $plugin_path, array( 'slug' => 'BH Slug' ) );
 		if ( empty( $data['slug'] ) ) {
 			return $options;
 		}
@@ -81,7 +81,7 @@ class PLS {
 
 		$options['package'] = add_query_arg(
 			array(
-				'license-key' => isset( $license_mapping[ $slug ] ) ? get_option( $license_mapping[ $slug ]['licenseIdStorageName'], '' ) : '',
+				'license-key'    => isset( $license_mapping[ $slug ] ) ? get_option( $license_mapping[ $slug ]['licenseIdStorageName'], '' ) : '',
 				'activation-key' => isset( $license_mapping[ $slug ] ) ? get_option( $license_mapping[ $slug ]['activationKeyStorageName'], '' ) : '',
 			),
 			$hiive->get_request_url()

--- a/includes/PLS.php
+++ b/includes/PLS.php
@@ -3,6 +3,8 @@
 namespace NewfoldLabs\WP\Module\PLS;
 
 use NewfoldLabs\WP\Module\PLS\RestApi\RestApi;
+use NewfoldLabs\WP\Module\PLS\Utilities\HiiveUtility;
+use NewfoldLabs\WP\Module\PLS\Utilities\PLSUtility;
 use NewfoldLabs\WP\Module\PLS\WPCLI\WPCLI;
 use NewfoldLabs\WP\ModuleLoader\Container;
 
@@ -27,6 +29,7 @@ class PLS {
 		$this->container = $container;
 
 		\add_action( 'init', array( __CLASS__, 'load_text_domain' ), 100 );
+		\add_filter( 'upgrader_package_options', array( __CLASS__, 'filter_upgrader_package_options' ) );
 
 		if ( Permissions::rest_is_authorized_admin() ) {
 			new RestApi();
@@ -48,6 +51,42 @@ class PLS {
 			false,
 			NFD_PLS_DIR . '/languages'
 		);
+	}
 
+	/**
+	 * Filter upgrader package options to append license_key and activation_key
+	 *
+	 * @param array $options The package options array.
+	 * @return array
+	 */
+	public static function filter_upgrader_package_options( $options ) {
+
+		// Get the plugin path.
+		$plugin_path = $options['hook_extra']['plugin'] ?? '';
+		if ( empty( $plugin_path ) ) {
+			return $options;
+		}
+
+		// Get the plugin slug.
+		$data = get_file_data(  WP_PLUGIN_DIR . '/' . $plugin_path, ['slug' => 'BH Slug'] );
+		if ( empty( $data['slug'] ) ) {
+			return $options;
+		}
+
+		$slug  = $data['slug'];
+		$hiive = new HiiveUtility( "/plugins/v1/{$slug}/download" );
+
+		$pls_utility     = new PLSUtility();
+		$license_mapping = $pls_utility->retrieve_license_storage_map();
+
+		$options['package'] = add_query_arg(
+			array(
+				'license-key' => isset( $license_mapping[ $slug ] ) ? get_option( $license_mapping[ $slug ]['licenseIdStorageName'], '' ) : '',
+				'activation-key' => isset( $license_mapping[ $slug ] ) ? get_option( $license_mapping[ $slug ]['activationKeyStorageName'], '' ) : '',
+			),
+			$hiive->get_request_url()
+		);
+
+		return $options;
 	}
 }

--- a/includes/PLS.php
+++ b/includes/PLS.php
@@ -74,7 +74,7 @@ class PLS {
 		}
 
 		$slug  = $data['slug'];
-		$hiive = new HiiveUtility( "/plugins/v1/{$slug}/download" );
+		$hiive = new HiiveUtility( "/releases/v1/plugins/{$slug}/download" );
 
 		$pls_utility     = new PLSUtility();
 		$license_mapping = $pls_utility->retrieve_license_storage_map();

--- a/includes/Utilities/HiiveUtility.php
+++ b/includes/Utilities/HiiveUtility.php
@@ -60,8 +60,8 @@ class HiiveUtility {
 	 * @return mixed|WP_Error The response from the API or a WP_Error if the request fails.
 	 */
 	public function send_request() {
-		// Construct the full URL by appending the endpoint to the base URL
-		$url = $this->api_base_url . $this->endpoint;
+
+		$url = $this->get_request_url();
 
 		// Check the connection to ensure the API is reachable
 		if ( ! HiiveConnection::is_connected() ) {
@@ -110,5 +110,15 @@ class HiiveUtility {
 
 		// Return the body of the response
 		return wp_remote_retrieve_body( $response );
+	}
+
+	/**
+	 * Return the request URL
+	 * Construct the full URL by appending the endpoint to the base URL
+	 *
+	 * @return string
+	 */
+	public function get_request_url() {
+		return $this->api_base_url . $this->endpoint;
 	}
 }


### PR DESCRIPTION
## Proposed changes

This PR adds the ability to filter plugin upgrade options, allowing customization of the download package URL by injecting a license key and activation key. This is part of the larger project, Solutions, and is used by Hiive to validate plugin licenses and activation before initiating the package download.

Please note that plugins are identified by the header data `BH Slug`.

## Type of Change

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
