### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable-translations jobs that push branches (prepare-pr-branch, create-translation-pr).
       pull-requests: write # Required for gh pr create and related PR updates in the reusable translation workflow.
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-pls'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,14 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for reusable-translations jobs that push branches (prepare-pr-branch, create-translation-pr).
+      pull-requests: write # Required for gh pr create and related PR updates in the reusable translation workflow.
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-pls'

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # Branch name comes from workflow env/context only; no checkout or GitHub API calls.
+    timeout-minutes: 30
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
+    timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
+    timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,8 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -17,8 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # Branch name comes from workflow env/context only; no checkout or GitHub API calls.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 10
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -33,6 +34,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable codecoverage workflow to push coverage HTML to gh-pages.
       pull-requests: write # Required for the reusable workflow to add or update coverage comments on pull requests.
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -29,8 +31,8 @@ jobs:
   codecoverage:
     needs: get-repo-name
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for the reusable codecoverage workflow to push coverage HTML to gh-pages.
+      pull-requests: write # Required for the reusable workflow to add or update coverage comments on pull requests.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,13 +8,15 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    permissions:
+      contents: read # Required for the reusable Crowdin download workflow to clone the (private) caller repository; PR creation uses PAT credentials inside the reusable workflow, not GITHUB_TOKEN write scopes.
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: read # Required for the reusable Crowdin download workflow to clone the (private) caller repository; PR creation uses PAT credentials inside the reusable workflow, not GITHUB_TOKEN write scopes.
+    timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -12,6 +12,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: read # Required for the reusable Crowdin upload workflow to clone the (private) caller repository.
+    timeout-minutes: 20
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,9 +3,15 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    permissions:
+      contents: read # Required for the reusable Crowdin upload workflow to clone the (private) caller repository.
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read        # Required for actions/checkout to clone the private repository.
       pull-requests: read   # Required for technote-space/get-diff-action to resolve changed files via the pulls API on pull_request events.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -10,6 +10,10 @@ on:
       - '**.php'
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
@@ -18,6 +22,9 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read        # Required for actions/checkout to clone the private repository.
+      pull-requests: read   # Required for technote-space/get-diff-action to resolve changed files via the pulls API on pull_request events.
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,10 +21,10 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to push the release branch and commits.
+      pull-requests: write # Required for the reusable workflow to open the release pull request (also uses gh with GITHUB_TOKEN).
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push the release branch and commits.
       pull-requests: write # Required for the reusable workflow to open the release pull request (also uses gh with GITHUB_TOKEN).
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # Webhook uses secrets.WEBHOOK_TOKEN with peter-evans/repository-dispatch; the default GITHUB_TOKEN is not used for GitHub API calls in this job.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # Webhook uses secrets.WEBHOOK_TOKEN with peter-evans/repository-dispatch; the default GITHUB_TOKEN is not used for GitHub API calls in this job.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 8 (`/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/auto-translate.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/brand-plugin-test-playwright.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/codecoverage-main.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/i18n-crowdin-download.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/i18n-crowdin-upload.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/lint-checker-php.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/newfold-prep-release.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created — no push) |
| Permissions commit | `669f174` |
| Timeouts commit | `cd282a3` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/lint-checker-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/codecoverage-main.yml` *(replaced `contents: read` with the audited empty default + comments.)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/brand-plugin-test-playwright.yml` *(replaced `contents: read` with the audited empty default + comments.)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/i18n-crowdin-upload.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/i18n-crowdin-download.yml` *(replaced overly broad workflow-level scopes with empty default + comments.)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/auto-translate.yml` *(normalized to include required comment preamble before `permissions: {}`.)* |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/satis-update.yml | 1 job was missing a scoped `permissions:` directive | Send Webhook | `permissions: {}` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/lint-checker-php.yml | 1 job was missing a scoped `permissions:` directive | Run PHP Code Sniffer | `contents: read`, `pull-requests: read` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/i18n-crowdin-upload.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-upload-workflow | `contents: read` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/i18n-crowdin-download.yml | 1 job was missing an explicit minimally scoped `permissions:` block (effective scope previously inherited from overly broad workflow permissions) | call-crowdin-workflow | `contents: read` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/brand-plugin-test-playwright.yml` :: top-level defaults: BEFORE `contents: read` -> AFTER `{}` (`permissions:` block with required comments only) — The repository default workflow token should deny scope until lifted per-job; callers should not widen read at workflow root when jobs differ. — [3] |
| 2 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/brand-plugin-test-playwright.yml` :: `Setup`: BEFORE `contents: read` -> AFTER `permissions: {}` — Branch name derivation uses only baked-in runner context; cloning the repo would be unnecessary privileged surface. — [3] |
| 3 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/codecoverage-main.yml` :: top-level defaults: BEFORE `contents: read` -> AFTER `{}` (`permissions:` block with required comments only) — Centralize granting read/write on the callable job only (`get-repo-name` never checks out sources). — [3] |
| 4 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/i18n-crowdin-download.yml` :: caller workflow inheritance: BEFORE `contents: write` + `pull-requests: write` at workflow root -> AFTER empty root + caller job `contents: read` only — Matches `newfold-labs/workflows`’ `i18n-crowdin-download.yml`, where PR creation intentionally uses PAT env (`GITHUB_TOKEN=${{ secrets.NEWFOLD_ACCESS_TOKEN }}`) instead of escalating the workflow `GITHUB_TOKEN`. — [3] |
| 5 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/codecoverage-main.yml` :: `codecoverage`: BEFORE permission keys without explanatory comments -> AFTER `contents: write` / `pull-requests: write` with aligned inline rationales referencing gh-pages publishes + PR commenting — Satisfies audit requirement for rationale per scope and matches sibling modules relying on `reusable-codecoverage.yml`. — [3] |
| 6 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/newfold-prep-release.yml` :: `Prepare Release`: BEFORE bare permissions keys -> AFTER the same scopes with explanatory comments keyed like other modules — Readers can see exactly why pushes/PR drafting need those scopes (`reusable-module-prep-release.yml` uses persisted credentials + `gh pr create`). — [3] |
| 7 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/newfold-prep-release.yml` :: `Prepare Release`: reordered YAML keys (`uses:` before annotated `permissions`) — Aligns with other audited repos for callable jobs so reviewers can skim secret + reusable wiring before scopes. — [2] |
| 8 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/auto-translate.yml` :: `translate`: BEFORE scopes without explanatory comments -> AFTER identical scopes with rationales tying them to commits/pushes/`gh pr` inside `reusable-translations.yml` — Mirrors the documented behavior of the reusable translations workflow (`prepare-pr-branch`, translators, PR automation). — [3] |
| 9 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/brand-plugin-test-playwright.yml` :: `Bluehost*` jobs: clarified comment text + reorganized YAML (`uses:` before annotated `permissions`, `secrets: inherit` placement) consistent with audited siblings — Cosmetic structure only after scopes validated against `module-plugin-test-playwright.yml`. — [2] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/satis-update.yml | Send Webhook | `30` | Three lightweight shell echoes plus repository dispatch rarely exceed a few minutes; thirty minutes avoids an orphaned stuck runner while permitting Crowdin/satellite outages. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/lint-checker-php.yml | Run PHP Code Sniffer | `30` | Composer installs plus PHPCS on diff hunks reliably finish sooner, but intermittent cache misses justify a bounded half-hour guard. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/codecoverage-main.yml | get-repo-name | `10` | Single echo step completes instantly yet still needs ceiling protection if the runner wedges before emitting outputs. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/codecoverage-main.yml | codecoverage | `60` | Reusable matrices across six PHP builds, Codeception/wpunit, merges, badges, and gh-pages pushes routinely take tens of minutes; one hour parallels other modules using the same reusable workflow without starving shorter jobs. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/brand-plugin-test-playwright.yml | Setup | `30` | Branch extraction is microseconds, but aligning with sibling modules keeps uniformity if future steps lengthen. |
| — | — | — | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/brand-plugin-test-playwright.yml` :: both Playwright aggregator jobs (`Bluehost…`, `Bluehost Dev…`) -> `90` — Each job fans out Composer/NPM installs, browser downloads, artifact uploads, and full Playwright suites; ninety minutes avoids indefinite consumption while honoring typical warm-cache runtimes documented in related repos. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/newfold-prep-release.yml | Prepare Release | `60` | `reusable-module-prep-release.yml` itself caps nested work near twenty minutes; sixty at the caller gives headroom for queueing and GitHub latency without matching unbounded nightly builds. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `20` | Upload jobs clone once and stream sources to Crowdin; twenty minutes aligns with reusable defaults while preventing hung HTTP calls from burning hours. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/i18n-crowdin-download.yml | call-crowdin-workflow | `30` | Matches generous headroom versus the reusable job’s shorter inner timeout (`20`) for larger translation batches/network jitter. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-pls/.github/workflows/auto-translate.yml | translate | `120` | `reusable-translations.yml` chains multiple heavyweight Composer/npm/Azure translation steps sequenced behind branch prep; sibling modules allot two hours exactly for the same reusable entry point. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `i18n-crowdin-download.yml` still forwards only `CROWDIN_PERSONAL_TOKEN` explicitly even though upstream `newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main` requires `secrets.NEWFOLD_ACCESS_TOKEN` for Crowdin-created PR flows; confirm repo/org secrets propagate through `GITHUB_TOKEN`/`NEWFOLD_ACCESS_TOKEN` substitution or augment the caller similarly to whichever template your org considers canonical (`wp-module-features` omits forwarding too — likely intentional reliance on centralized secrets binding). Confidence on runtime behavior `[2]` pending repository settings review. |


